### PR TITLE
4 Series Processor Fix - UpdateWatchListen()

### DIFF
--- a/program/Rooms-Sources Controller.ush
+++ b/program/Rooms-Sources Controller.ush
@@ -6,7 +6,7 @@
   Sgntr=UserSPlus
   RelVrs=1
   IntStrVrs=1
-  SPlusVrs=4.04.01
+  SPlusVrs=4.05.01
   CrossCplrVrs=1.3
 [END]
 [BEGIN]
@@ -15,8 +15,8 @@
 [BEGIN]
   ObjTp=Symbol
   Exclusions=1,19,20,21,88,89,167,168,179,213,214,215,216,217,225,226,248,249,266,267,310,718,756,854,
-  Exclusions_CDS=5
-  Inclusions_CDS=6
+  Exclusions_CDS=
+  Inclusions_CDS=5,6,7
   Name=Rooms-Sources Controller
   SmplCName=Rooms-Sources Controller.usp
   Code=1

--- a/program/Rooms-Sources Controller.usp
+++ b/program/Rooms-Sources Controller.usp
@@ -661,7 +661,7 @@ FUNCTION UpdateListen(INTEGER source)
 
 FUNCTION UpdateWatchListen()
 {
-    INTEGER i, room, source;
+    INTEGER i, room, source, watch_size, listen_size;
 
     room = IdToIndex(Room_Is);
 
@@ -690,9 +690,9 @@ FUNCTION UpdateWatchListen()
             }
         }
     }
-
-    Watches_Size = 0;
-    Listens_Size = 0;
+    
+    watch_size = 0;
+    listen_size = 0;
 
     SETARRAY(__Watch_Source__, 0);
     SETARRAY(__Source_Watch__, 0);
@@ -708,17 +708,19 @@ FUNCTION UpdateWatchListen()
 
         IF(Source_Has_Video[source])
         {
-            Watches_Size = Watches_Size + 1;
-            __Watch_Source__[Watches_Size] = source;
-            __Source_Watch__[source] = Watches_Size;
+            watch_size = watch_size + 1;
+            Watches_Size = watch_size;
+            __Watch_Source__[watch_size] = source;
+            __Source_Watch__[source] = watch_size;
 
             UpdateWatch(source);
         }
         ELSE
         {
-            Listens_Size = Listens_Size + 1;
-            __Listen_Source__[Listens_Size] = source;
-            __Source_Listen__[source] = Listens_Size;
+            listen_size = listen_size + 1;
+            Listens_Size = listen_size;
+            __Listen_Source__[listen_size] = source;
+            __Source_Listen__[source] = listen_size;
 
             UpdateListen(source);
         }


### PR DESCRIPTION
Fixes #100 

UpdateWatchListen() wasn't updating correctly. Watches_Size and Listens_Size wouldn't get updated right away causing the source list to not generate correctly.